### PR TITLE
Codecov integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: swift
-xcode_project: SwiftYNAB/SwiftYNAB.xcodeproj
+xcode_workspace: SwiftYNAB.xcworkspace
 xcode_scheme: SwiftYNAB
 xcode_destination: platform=iOS Simulator,OS=11.0.1,name=iPhone X
 osx_image: xcode10.2
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/andrebocchini/swiftynab.svg?branch=master)](https://travis-ci.org/andrebocchini/swiftynab)
+[![Build Status](https://travis-ci.org/andrebocchini/swiftynab.svg?branch=master)](https://travis-ci.org/andrebocchini/swiftynab)  [![codecov](https://codecov.io/gh/andrebocchini/swiftynab/branch/master/graph/badge.svg)](https://codecov.io/gh/andrebocchini/swiftynab)
+
+
 
 # SwiftYNAB
 

--- a/SwiftYNAB/SwiftYNAB.xcodeproj/xcshareddata/xcschemes/SwiftYNAB.xcscheme
+++ b/SwiftYNAB/SwiftYNAB.xcodeproj/xcshareddata/xcschemes/SwiftYNAB.xcscheme
@@ -26,7 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "30AADF622277CBDF00AE95B8"
+            BuildableName = "SwiftYNAB.framework"
+            BlueprintName = "SwiftYNAB"
+            ReferencedContainer = "container:SwiftYNAB.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO"


### PR DESCRIPTION
Updated the project to collect code coverage data, and updated `.travis.yml` to send code coverage information to [codecov.io](https://codecov.io).