### PR TITLE
Fix path for specific category request

### DIFF
--- a/SwiftYNAB/SwiftYNAB/requests/CategoryRequests.swift
+++ b/SwiftYNAB/SwiftYNAB/requests/CategoryRequests.swift
@@ -48,7 +48,7 @@ struct CategoryRequest {
 extension CategoryRequest: Request {
     
     var path: String {
-        return "/v1/budgets/\(self.budgetId)/category/\(self.categoryId)"
+        return "/v1/budgets/\(self.budgetId)/categories/\(self.categoryId)"
     }
     
 }

--- a/SwiftYNAB/SwiftYNABTests/requests/CategoryRequestTests.swift
+++ b/SwiftYNAB/SwiftYNABTests/requests/CategoryRequestTests.swift
@@ -33,7 +33,7 @@ class CategoriesRequestTests: XCTestCase {
     func testCategoryRequest() {
         let request = CategoryRequest(budgetId: "43dcbde6-ccf4-4367-9d13-d6d7e9beeb99",
                                       categoryId: "9b6ff04f-b123-d126-4605-0ae2c2f5e3ba")
-        XCTAssertEqual(request.path, "/v1/budgets/43dcbde6-ccf4-4367-9d13-d6d7e9beeb99/category/9b6ff04f-b123-d126-4605-0ae2c2f5e3ba")
+        XCTAssertEqual(request.path, "/v1/budgets/43dcbde6-ccf4-4367-9d13-d6d7e9beeb99/categories/9b6ff04f-b123-d126-4605-0ae2c2f5e3ba")
         XCTAssertEqual(request.method, "GET")
         XCTAssertNil(request.query)
         XCTAssertNil(request.body)


### PR DESCRIPTION
According to [documentation](https://api.youneedabudget.com/v1#/Transactions), path should use `categories` word:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/13601748/70869141-7c563e80-1f90-11ea-8be7-df077a86adb9.png">
