### PR TITLE
make `payeeId` optional in SaveTransaction.init

### DIFF
--- a/SwiftYNAB/SwiftYNAB/models/SaveTransaction.swift
+++ b/SwiftYNAB/SwiftYNAB/models/SaveTransaction.swift
@@ -67,7 +67,7 @@ public struct SaveTransaction: Codable {
                 date: String,
                 amount: Int,
                 accountId: String,
-                payeeId: String,
+                payeeId: String? = nil,
                 payeeName: String,
                 importId: String? = nil) {
         self.id = id


### PR DESCRIPTION
* The `payeeId` is an optional item of the payload (and `SaveTransaction`'s `payeeId` property is also optional)