### PR TITLE
Fixes #8 - misplacement of closing parenthesis in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftYNABTests",
-            dependencies: ["SwiftYNAB"]),
-            path: "SwiftYNAB/SwiftYNABTests"
+            dependencies: ["SwiftYNAB"],
+            path: "SwiftYNAB/SwiftYNABTests")
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
This fixes a small typo where the closing parenthesis was on the wrong line in the package definition.