### PR TITLE
Make SwiftYNABError public & throw .apiError

### DIFF
--- a/SwiftYNAB/SwiftYNAB/error/SwiftYNABError.swift
+++ b/SwiftYNAB/SwiftYNAB/error/SwiftYNABError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Errors that occur during encoding or decoding of JSON requests and responses
-enum SwiftYNABError: Error {
+public enum SwiftYNABError: Error {
     /// Failure decoding JSON
     case decodingFailure(message: String)
     /// Failure encoding JSON
@@ -23,7 +23,7 @@ enum SwiftYNABError: Error {
 }
 
 extension SwiftYNABError: Equatable {
-    static func == (lhs: SwiftYNABError, rhs: SwiftYNABError) -> Bool {
+    public static func == (lhs: SwiftYNABError, rhs: SwiftYNABError) -> Bool {
         switch (lhs, rhs) {
         case (.decodingFailure, .decodingFailure):
             return true

--- a/SwiftYNAB/SwiftYNAB/networking/Client.swift
+++ b/SwiftYNAB/SwiftYNAB/networking/Client.swift
@@ -40,7 +40,11 @@ extension Client: ClientType {
 
         try Task.checkCancellation()
 
-        if isHTTPError(response: urlResponse) {
+       if isHTTPError(response: urlResponse) {
+           if let errorDetails = try? serializer.decode(ErrorDetail.self, from: data) {
+               throw SwiftYNABError.apiError(detail: errorDetails)
+           }
+
             guard let httpURLResponse = urlResponse as? HTTPURLResponse else {
                 throw SwiftYNABError.unknown
             }

--- a/SwiftYNAB/SwiftYNABTests/services/AccountServiceTests.swift
+++ b/SwiftYNAB/SwiftYNABTests/services/AccountServiceTests.swift
@@ -89,7 +89,7 @@ class AccountServiceTests: XCTestCase {
         XCTAssertEqual(expectedAccount, actualResponse[0])
     }
 
-    func testGeAccountsThrowsErrorWhenRequestFails() async throws {
+    func testGeAccountsThrowsHttpErrorWhenRequestFails() async throws {
         let expectedError = SwiftYNABError.httpError(statusCode: 500)
         let client = MockFailureClient(expectedError: expectedError)
         let service = AccountService(client: client)
@@ -99,6 +99,24 @@ class AccountServiceTests: XCTestCase {
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertEqual(error as? SwiftYNABError, .httpError(statusCode: 500))
+        }
+    }
+
+    func testGeAccountsThrowsApiErrorWhenRequestFails() async throws {
+        let errorDetails = ErrorDetail(
+            id: "403.2",
+            name: "trial_expired",
+            detail: "The trial for this account has expired"
+        )
+        let expectedError = SwiftYNABError.apiError(detail: errorDetails)
+        let client = MockFailureClient(expectedError: expectedError)
+        let service = AccountService(client: client)
+
+        do {
+            _ = try await service.getAccounts(budgetId: "budget_id", lastKnowledgeOfServer: 1)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? SwiftYNABError, .apiError(detail: errorDetails))
         }
     }
 


### PR DESCRIPTION
Hi @andrebocchini ,
- I was trying to inspect the `SwiftYNABError` in my calling code but wasn't able to because it wasn't publicly available. Updated it's accessor to `public`. 
- It seems `SwiftYNABError.apiError` was never thrown by `Client`.  The `ErrorDetails` and other infrastructure (unit tests and json files) was in place except the actual impl in the Client.swift 😊.  If it's unable to create the `ErrorDetails`, will fallback to  `.httpError`.
- Added a unit tests when an `apiError` is expected.