### PR TITLE
bugfix to allow optionals in BudgetSummary model

### DIFF
--- a/SwiftYNAB.podspec
+++ b/SwiftYNAB.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name  = "SwiftYNAB"
-  s.version = "2.1.1"
+  s.version = "2.1.2"
   s.summary = "YNAB API Framework"
   s.description = "SwiftYNAB is an iOS/macOS/tvOS/WatchOS framework for the You Need a Budget API"
   s.homepage = "http://github.com/andrebocchini/swiftynab"

--- a/SwiftYNAB/SwiftYNAB/models/BudgetSummary.swift
+++ b/SwiftYNAB/SwiftYNAB/models/BudgetSummary.swift
@@ -26,8 +26,8 @@ public struct BudgetSummary: Codable, Equatable {
     public let lastMonth: String
 
     /// Date formatting settings
-    public let dateFormat: DateFormat
+    public let dateFormat: DateFormat?
 
     /// Currency formatting settings
-    public let currencyFormat: CurrencyFormat
+    public let currencyFormat: CurrencyFormat?
 }


### PR DESCRIPTION
This PR is in regards to #12 It makes those two properties as Optionals when they are null from the api json response.

[comment describing issue](https://github.com/andrebocchini/swiftynab/issues/12#issuecomment-2471886389)

I can now get budgets with no error:
```
Content view launched
Token ZOgP_76Ov5pv7fbbw6zA8U-sSxJYzwo4r_h79COZ4UU
Logged in status: true
2024_Round2 (Archived on 2024-08-17)
My Budget (Archived on 2022-03-20)
New2 Budget
My Budget
2024_Round3 (Archived on 2024-09-18)
2024TakingCharge:( (Archived on 2024-02-02)
2024_Round4
My Budget
My Budget
2021-2023 Transactions
New1 Budget (Archived on 2022-04-27) (Archived on 2023-07-05)
2023TakingCharge (Archived on 2024-01-04)
```